### PR TITLE
CSV table for run info db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Python
+*_pycache__*
+
 # Prerequisites
 *.d
 

--- a/python/parseWcteDaqRunsHtml.py
+++ b/python/parseWcteDaqRunsHtml.py
@@ -47,3 +47,11 @@ print('runsDict = ', runsDict)
 print()
 print()
 
+# Save data to csv
+import numpy  as np
+import pandas as pd
+
+df = pd.DataFrame(columns=["Run", "Momentum", "Charge"]) # TO-DO: Add refraction indexes info
+for (run, momentum) in runsDict.items(): df.loc[len(df)] = (run, abs(momentum), np.sign(momentum))
+df.to_csv("run_info_db.csv", index=False)
+


### PR DESCRIPTION
- Update .gitignore
- Save run info as csv table (can be easily read by `pandas.read_csv()`)