### PR TITLE
Update to the window integration code and new ParticleID.py code

### DIFF
--- a/complete_pre-processing.sh
+++ b/complete_pre-processing.sh
@@ -8,16 +8,16 @@ do
     else
     config="config/config_hodoscope.json"
     fi
-    echo "Starting the pre-processing for run "$run""
-#     #this code does the peak finding and timing and creates the first ntuple, careful at this stage the signalTimeCorrected branch doesn't actually have the corrected timings
-    python python/new_analysis/process_waveform_analysis.py data/root_run_$run.root $config peakAnalysed_$run.root
-
-# # #     These codes, written by Arturo synchronise the timings across digitisers and then overwrites the signalTimeCorrected with the correctly shifted timings
-    root -l -b -q 'macros/triggerTimeDrift.C("peakAnalysed_'$run'.root")'
-    root -l -b -q 'macros/timeCorrection.C("peakAnalysed_'$run'.root", "triggerTimeDrift.txt", "peakAnalysed_timeCorr_'$run'.root", "timingCorrectionInfo_'$run'.root")'
+#     echo "Starting the pre-processing for run "$run""
+# #     #this code does the peak finding and timing and creates the first ntuple, careful at this stage the signalTimeCorrected branch doesn't actually have the corrected timings
+#     python python/new_analysis/process_waveform_analysis.py data/root_run_$run.root $config peakAnalysed_$run.root
+#
+# # # #     These codes, written by Arturo synchronise the timings across digitisers and then overwrites the signalTimeCorrected with the correctly shifted timings
+#     root -l -b -q 'macros/triggerTimeDrift.C("peakAnalysed_'$run'.root")'
+#     root -l -b -q 'macros/timeCorrection.C("peakAnalysed_'$run'.root", "triggerTimeDrift.txt", "peakAnalysed_timeCorr_'$run'.root", "timingCorrectionInfo_'$run'.root")'
 
 #   This code performs the timing alignment of the hits (adds an arbitrary offset to the entire PMT timings to align the integration windows
 #   It performs the window integration and converts signal to PE units.
-    python python/new_analysis/process_ac_waveform_analysis.py data/root_run_$run.root peakAnalysed_timeCorr_$run.root $config peakAnalysed_timeCorr_windInt_$run.root
+    python python/new_analysis/process_ac_waveform_analysis.py data/root_run_$run.root peakAnalysed_timeCorr_$run.root $config peakAnalysed_timeCorr_windIntTest3_$run.root
 
 done

--- a/complete_pre-processing.sh
+++ b/complete_pre-processing.sh
@@ -6,7 +6,7 @@ for run in $@
 do
     if [ $run -le 579 ]
     then
-    config="config/config_noHodoscope_-5_to_15ns.json"
+    config="config/config_noHodoscope.json"
     else
     config="config/config_hodoscope.json"
     fi

--- a/complete_pre-processing.sh
+++ b/complete_pre-processing.sh
@@ -1,23 +1,26 @@
 #This is a code that does all of the pre-processing required to go from a base root file to the final analysable code , you can call it with multiple run inputs
 
+timingRange="final"
+
 for run in $@
 do
     if [ $run -le 579 ]
     then
-    config="config/config_noHodoscope.json"
+    config="config/config_noHodoscope_-5_to_15ns.json"
     else
     config="config/config_hodoscope.json"
     fi
-#     echo "Starting the pre-processing for run "$run""
+    echo "Starting the pre-processing for run "$run""
 # #     #this code does the peak finding and timing and creates the first ntuple, careful at this stage the signalTimeCorrected branch doesn't actually have the corrected timings
-#     python python/new_analysis/process_waveform_analysis.py data/root_run_$run.root $config peakAnalysed_$run.root
-#
-# # # #     These codes, written by Arturo synchronise the timings across digitisers and then overwrites the signalTimeCorrected with the correctly shifted timings
-#     root -l -b -q 'macros/triggerTimeDrift.C("peakAnalysed_'$run'.root")'
-#     root -l -b -q 'macros/timeCorrection.C("peakAnalysed_'$run'.root", "triggerTimeDrift.txt", "peakAnalysed_timeCorr_'$run'.root", "timingCorrectionInfo_'$run'.root")'
+    python python/new_analysis/process_waveform_analysis.py data/root_run_$run.root $config peakAnalysed_$run.root
 
-#   This code performs the timing alignment of the hits (adds an arbitrary offset to the entire PMT timings to align the integration windows
+# # # # #     These codes, written by Arturo synchronise the timings across digitisers and then overwrites the signalTimeCorrected with the correctly shifted timings
+    root -l -b -q 'macros/triggerTimeDrift.C("peakAnalysed_'$run'.root")'
+    root -l -b -q 'macros/timeCorrection.C("peakAnalysed_'$run'.root", "triggerTimeDrift.txt", "peakAnalysed_timeCorr_'$run'.root", "timingCorrectionInfo_'$run'.root")'
+
+# #   This code performs the timing alignment of the hits (adds an arbitrary offset to the entire PMT timings to align the integration windows
 #   It performs the window integration and converts signal to PE units.
-    python python/new_analysis/process_ac_waveform_analysis.py data/root_run_$run.root peakAnalysed_timeCorr_$run.root $config peakAnalysed_timeCorr_windIntTest3_$run.root
+# be careful: if you use the coincidence check you need to make sure that you are using the peakAnalysed_timeCorr code otherwise there will be format issues
+    python python/new_analysis/process_ac_waveform_analysis.py data/root_run_$run.root peakAnalysed_timeCorr_$run.root $config WindowIntMatched_""$timingRange""_$run.root
 
 done

--- a/config/analyse_000432.json
+++ b/config/analyse_000432.json
@@ -1,0 +1,33 @@
+{
+    "LowMomentumAnalysis":
+
+    {
+        "comment" : "This is the config file that is used for the low momentum set-up analysis, it holds information about the runs",
+        "channelNames" : ["ACT0L","ACT0R", "ACT1L", "ACT1R", "ACT2L", "ACT2R", "ACT3L", "ACT3R", "TOF00", "TOF01", "TOF02", "TOF03", "TOF10", "TOF11", "TOF12", "TOF13", "Hole0", "Hole1", "PbGlass"],
+
+        "dataFile" : "/home/ac4317/Laptops/Year1/WCTE/BeamTestJuly2023/DataAnalysis/data/analysis-code/T9BeamTestAna/WindowIntMatched_final_000432.root",
+
+        "runNumber" : 432,
+        "comment" : "run momentum  in MeV/c, positive is positively charged beam and negative is negatively charged",
+        "runMomentum" : 460,
+        "runRefractiveIndex": 1.047,
+        "comment" : "text file that has the selection cuts, read as a function of momentum, reference set of cuts, which will be read as the default",
+        "referenceSelectionCutFile" : "referenceNumberParticles.txt",
+        "comment" : "to run in batch mode, plots are saved instead of output and the selection does not require user input",
+        "batchMode" : false,
+
+        "comment" : "Decide if we want to look at only events with exactly n coincidences, default n = 1",
+        "nCoincidenceSelectionBool" : true,
+        "nCoincidenceSelectionValue" : 1,
+
+        "comment" : "Decide if we want to use the energy deposited in the trigger scintillators to select good events",
+        "triggerScintillatorSelectionBool" : true,
+        "triggerScintillatorSelectionValue" : 40,
+
+        "comment": "needs to be added onto the class file",
+        "comment": "if we want to output a rootfile with the particleType as an iformation, slows down the process a lot",
+        "saveRootFile": false,
+
+    }
+
+}

--- a/config/config_hodoscope.json
+++ b/config/config_hodoscope.json
@@ -26,7 +26,7 @@
             "ActiveChannels"     : [true, true, true, true, true, true, true, false,
 				    true, true, true, true, true, true, true, true,
 				    true, true, true, true, true, true, true, true,
-				    true, true, true, true, true, true, true, true,],
+				    true, true, true, true, true, true, true, true],
 	    
         "comment"            : "Measure charge (integral of signal-pedestal in the analysis window)",
             "ChargeMeasurements" : [true, true, true, true, true, true, true, true,
@@ -91,15 +91,25 @@
 
 		"comment" : "lower boundary for the window integration, now that the timing is aligned we can have a  smaller integration window to get rid of the scintilaltion light in ACTs, different channels have a different integration window length",
 
-			"window_lower_bound" : [-5, -5, -5, -5, -5, -5, -5, -5,
+			"window_lower_bound" : [-16, -16, -16, -16, -16, -16, -16, -16,
 									-5, -5, -5, -5, -5, -5, -5, -5,
-									-5, -5, -5, -5, -5, -5, -5, -5,
-									-5, -5, -5, -5, -5, -5, -5, -5,],
+									-16, -26, -26, -26, -26, -26, -26, -26,
+									-26, -26, -26, -26, -26, -26, -26, -26],
 
-			"window_upper_bound" : [15, 15, 15, 15, 15, 15, 15, 15,
+			"window_upper_bound" : [45, 45, 45, 45, 45, 45, 45, 45,
 									15, 15, 15, 15, 15, 15, 15, 15,
-									15, 15, 15, 15, 15, 15, 15, 15,
-									15, 15, 15, 15, 15, 15, 15, 15,],
+									55, 45, 45, 45, 45, 45, 45, 45,
+									45, 45, 45, 45, 45, 45, 45, 45],
+
+		"comment" : "position of of the detectors in z along the beam dierction w.r.t. TS1 to calculate the particle travel time for window integration",
+									
+
+		"PMTLocRelativeToTOF1" : [-0.228, -0.228, -0.078, -0.078, 3.787, 3.787, 0.232, 0,
+		-3.708, -3.708, -3.708, -3.708, 0, 0, 0, 0,
+		3.877, 2.759, 2.759, 2.759, 2.759, 2.759, 2.759, 2.759,
+		2.759, 2.759, 2.759, 2.759, 2.759, 2.759, 2.759, 2.759],
+
+		"distanceTOF1toTOF0" : 3.708
 
 	}
 }

--- a/config/config_hodoscope.json
+++ b/config/config_hodoscope.json
@@ -98,7 +98,7 @@
 
 			"window_upper_bound" : [45, 45, 45, 45, 45, 45, 45, 45,
 									15, 15, 15, 15, 15, 15, 15, 15,
-									55, 45, 45, 45, 45, 45, 45, 45,
+									75, 45, 45, 45, 45, 45, 45, 45,
 									45, 45, 45, 45, 45, 45, 45, 45],
 
 		"comment" : "position of of the detectors in z along the beam dierction w.r.t. TS1 to calculate the particle travel time for window integration",

--- a/config/config_noHodoscope.json
+++ b/config/config_noHodoscope.json
@@ -61,11 +61,17 @@
 				    540, 540, 80, 300, 300, 300, 300, 300,
 				    300, 300, 300, 300, 300, 300, 300, 300],
 
-		"comment" : "1pe position in the signal in V from a DR data run (502)",
-			"PMTgain" : [0.30446, 0.6183148, 0.2150617, 0.316799, 0.2275831, 0.171613, 0.2256, 0.295012,
+		"comment" : "1pe position in the signal in V from a DR data run (502) - previous values, prior to Jiri's correction",
+			"comment" : [0.30446, 0.6183148, 0.2150617, 0.316799, 0.2275831, 0.171613, 0.2256, 0.295012,
 						  0.04457263158, 0.049545, 0.04662082192, 0.03502604651, 0.03854842105, 0.06932761905, 0.06069396226, 0.06920426087,
 						 0.03495, 0.04052, 1, 1, 1, 1, 1, 1,
 						 1, 1, 1, 1, 1, 1, 1, 1],
+
+		"comment" : "1pe position in the signal in V from a DR data run (502), updated by Jiri. Doc: https://docs.google.com/presentation/d/1aCE9BzC6dtgfDU05gHSt1MubaXQ1T-8gZ7K7MrQn2hg/edit?usp=sharing",
+			"PMTgain" : [0.3449947066184987, 0.6928315386973128, 0.21894343315858797, 0.30728713831798987, 0.23347310213569253, 0.1746068588471205, 0.22814108321423682, 0.2968876175093516,
+			0.05840403822142006, 0.06336915057935058, 0.10330741612905013, 0.0665263903692531, 0.03734780536275262, 0.07822458854082591, 0.07082107273729302, 0.09546272223281003,
+			0.03495, 0.04052, 1, 1, 1, 1, 1, 1,
+			1, 1, 1, 1, 1, 1, 1, 1],
 
         "comment" : "Analysis is done on the data in the analysis bin window.",
             "AnalysisWindowLow"  : [ 0, 0, 0, 0, 0, 0, 0, 0,
@@ -97,15 +103,24 @@
 
 		"comment" : "lower boundary for the window integration, now that the timing is aligned we can have a  smaller integration window to get rid of the scintilaltion light in ACTs, different channels have a different integration window length",
 
-		"window_lower_bound" : [-30, -30, -30, -30, -30, -30, -30, -30,
-								-30, -30, -30, -30, -30, -30, -30, -30,
-								-30, -30, -30, 0, 0, 0, 0, 0,
-								0, 0, 0, 0, 0, 0, 0, 0,],
+		"window_lower_bound" : [-16, -16, -16, -16, -16, -16, -16, -16,
+								-5, -5, -5, -5, -5, -5, -5, -5,
+								-16, -16, -16, 0, 0, 0, 0, 0,
+								0, 0, 0, 0, 0, 0, 0, 0],
 
-		"window_upper_bound" : [3, 3, 3, 3, 3, 3, 3, 3,
-								3, 3, 3, 3, 3, 3, 3, 3,
-								3, 3, 3, 0, 0, 0, 0, 0,
-								0, 0, 0, 0, 0, 0, 0, 0,],
+		"window_upper_bound" : [45, 45, 45, 45, 45, 45, 45, 45,
+								15, 15, 15, 15, 15, 15, 15, 15,
+								45, 45, 55, 0, 0, 0, 0, 0,
+								0, 0, 0, 0, 0, 0, 0, 0],
+
+		"comment": "To correctly caluclate the expected arrival time of particles we need to take into account their traveling time from the reference detector to to detector we are looking at (in units of meter)",
+
+		"PMTLocRelativeToTOF1" : [0.13, 0.13, 0.28, 0.28, 0.43, 0.43, 0.68, 0.68,
+		-3.49, -3.49, -3.49, -3.49, 0, 0, 0, 0,
+		0.05, 0.68, 1.08, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0],
+
+		"distanceTOF1toTOF0" : 3.49
 
 	}
 }

--- a/config/config_noHodoscope.json
+++ b/config/config_noHodoscope.json
@@ -97,14 +97,14 @@
 
 		"comment" : "lower boundary for the window integration, now that the timing is aligned we can have a  smaller integration window to get rid of the scintilaltion light in ACTs, different channels have a different integration window length",
 
-		"window_lower_bound" : [-16, -16, -16, -16, -16, -16, -16, -16,
-								-16, -16, -16, -16, -16, -16, -16, -16,
-								-16, -16, -16, 0, 0, 0, 0, 0,
+		"window_lower_bound" : [-30, -30, -30, -30, -30, -30, -30, -30,
+								-30, -30, -30, -30, -30, -30, -30, -30,
+								-30, -30, -30, 0, 0, 0, 0, 0,
 								0, 0, 0, 0, 0, 0, 0, 0,],
 
-		"window_upper_bound" : [35, 35, 35, 35, 35, 35, 35, 35,
-								35, 35, 35, 35, 35, 35, 35, 35,
-								35, 35, 35, 0, 0, 0, 0, 0,
+		"window_upper_bound" : [3, 3, 3, 3, 3, 3, 3, 3,
+								3, 3, 3, 3, 3, 3, 3, 3,
+								3, 3, 3, 0, 0, 0, 0, 0,
 								0, 0, 0, 0, 0, 0, 0, 0,],
 
 	}

--- a/config/config_noHodoscope.json
+++ b/config/config_noHodoscope.json
@@ -110,7 +110,7 @@
 
 		"window_upper_bound" : [45, 45, 45, 45, 45, 45, 45, 45,
 								15, 15, 15, 15, 15, 15, 15, 15,
-								45, 45, 55, 0, 0, 0, 0, 0,
+								45, 45, 75, 0, 0, 0, 0, 0,
 								0, 0, 0, 0, 0, 0, 0, 0],
 
 		"comment": "To correctly caluclate the expected arrival time of particles we need to take into account their traveling time from the reference detector to to detector we are looking at (in units of meter)",

--- a/config/config_noHodoscope_analysis.json
+++ b/config/config_noHodoscope_analysis.json
@@ -3,14 +3,25 @@
 
     {
         "comment" : "This is the config file that is used for the low momentum set-up analysis, it holds information about the runs",
+        "comment" : ["ACT0L","ACT0R", "ACT1L", "ACT1R", "ACT2L", "ACT2R", "ACT3L", "ACT3R",
+        "TOF00", "TOF01", "TOF02", "TOF03", "TOF10", "TOF11", "TOF12", "TOF13",
+        "Hole0", "Hole1", "PbGlass"],
+        "comment" : ["ACT0L", "ACT0R", "ACT1L", "ACT1R", "ACT3L", "ACT3R", "TriggerScint", null,
+        "TOF00", "TOF01", "TOF02", "TOF03", "TOF10", "TOF11", "TOF12", "TOF13",
+        "PbGlass", "HD8", "HD9", "HD10", "HD11", "HD12", "HD13", "HD14",
+        "HD0", "HD1", "HD2", "HD3", "HD4", "HD5", "HD6", "HD7"],
+        "channelNames" : ["ACT0L", "ACT0R", "PbGlass"],
+        "comment": "/home/ac4317/Laptops/Year1/WCTE/BeamTestJuly2023/DataAnalysis/data/analysis-code/T9BeamTestAna/peakAnalysed_timeCorr_windIntMatched-5to15_000502.root",
+        
+        "comment": "/home/ac4317/Laptops/Year1/WCTE/BeamTestJuly2023/DataAnalysis/data/analysis-code/T9BeamTestAna/peakAnalysed_timeCorr_windIntMatched-16to45_000432.root",
 
-        "ChannelNames" : ["ACT0L", "ACT0R", "ACT1L", "ACT1R", "ACT2L", "ACT2R", "ACT3L", "ACT3R",
-                        "TOF00", "TOF01", "TOF02", "TOF03", "TOF10", "TOF11", "TOF12", "TOF13",
-                        "Hole0", "Hole1", "PbGlass"],
-        "dataFile": "peakAnalysed_timeCorr_windIntCorrMatched_000432.root",
-        "runNumber" : 432,
+        "comment" :"/home/ac4317/Laptops/Year1/WCTE/BeamTestJuly2023/DataAnalysis/data/analysis-code/T9BeamTestAna/peakAnalysed_timeCorr_windIntMatched-5to15000735.root",
+
+        "dataFile" : "/home/ac4317/Laptops/Year1/WCTE/BeamTestJuly2023/DataAnalysis/data/analysis-code/T9BeamTestAna/test_-16_to_45ns_000735.root",
+
+        "runNumber" : 735,
         "comment" : "run momentum  in MeV/c, positive is positively charged beam and negative is negatively charged",
-        "runMomentum" : 460,
+        "runMomentum" : 800,
         "runRefractiveIndex": 1.047,
         "comment" : "text file that has the selection cuts, read as a function of momentum, reference set of cuts, which will be read as the default",
         "referenceSelectionCutFile" : "referenceNumberParticles.txt",
@@ -26,17 +37,9 @@
         "triggerScintillatorSelectionValue" : 40,
 
 
-
-
-
-        #needs to be added onto the class file
+        "comment": "needs to be added onto the class file",
         "comment": "if we want to output a rootfile with the particleType as an iformation, slows down the process a lot",
         "saveRootFile": false,
-
-
-
-
-
 
     }
 

--- a/config/config_noHodoscope_analysis.json
+++ b/config/config_noHodoscope_analysis.json
@@ -1,0 +1,43 @@
+{
+    "LowMomentumAnalysis":
+
+    {
+        "comment" : "This is the config file that is used for the low momentum set-up analysis, it holds information about the runs",
+
+        "ChannelNames" : ["ACT0L", "ACT0R", "ACT1L", "ACT1R", "ACT2L", "ACT2R", "ACT3L", "ACT3R",
+                        "TOF00", "TOF01", "TOF02", "TOF03", "TOF10", "TOF11", "TOF12", "TOF13",
+                        "Hole0", "Hole1", "PbGlass"],
+        "dataFile": "peakAnalysed_timeCorr_windIntCorrMatched_000432.root",
+        "runNumber" : 432,
+        "comment" : "run momentum  in MeV/c, positive is positively charged beam and negative is negatively charged",
+        "runMomentum" : 460,
+        "runRefractiveIndex": 1.047,
+        "comment" : "text file that has the selection cuts, read as a function of momentum, reference set of cuts, which will be read as the default",
+        "referenceSelectionCutFile" : "referenceNumberParticles.txt",
+        "comment" : "to run in batch mode, plots are saved instead of output and the selection does not require user input",
+        "batchMode" : false,
+
+        "comment" : "Decide if we want to look at only events with exactly n coincidences, default n = 1",
+        "nCoincidenceSelectionBool" : true,
+        "nCoincidenceSelectionValue" : 1,
+
+        "comment" : "Decide if we want to use the energy deposited in the trigger scintillators to select good events",
+        "triggerScintillatorSelectionBool" : true,
+        "triggerScintillatorSelectionValue" : 40,
+
+
+
+
+
+        #needs to be added onto the class file
+        "comment": "if we want to output a rootfile with the particleType as an iformation, slows down the process a lot",
+        "saveRootFile": false,
+
+
+
+
+
+
+    }
+
+}

--- a/python/lowMomentum_analysis.py
+++ b/python/lowMomentum_analysis.py
@@ -2,9 +2,11 @@
 
 import uproot as ur
 import matplotlib.pyplot as plt
+import math
 import numpy as np
 import pandas as pd
 import sys
+import awkward as ak
 
 
 class LowMomentumAnalysis:
@@ -24,67 +26,392 @@ class LowMomentumAnalysis:
         self.nCoincidenceSelectionValue = config["nCoincidenceSelectionValue"]
 
         #Selection of events based on the dE/dx of particles in the trigger scintillator
-        self.triggerScintillatorSelectionBool = config["triggerScintillatorSelection"]
+        self.triggerScintillatorSelectionBool = config["triggerScintillatorSelectionBool"]
         self.triggerScintillatorSelectionValue = config["triggerScintillatorSelectionValue"]
 
 
         self.openedFile = None
         #looking only at the window integrated charge
         #arrays holding the dataframes
-        self.arrayDataFramesCharge = []
-        self.arrayDataFramesTime = []
+        self.arrayData = []
 
         #Good event selection, by default
         self.nCoincidenceSelectionPassed = None
         self.triggerScintillatorSelectionPassed = None
 
+        #define some basic numbers
+        self.numberOfTOFpmt = 4
+        self.flag = -9999
+        self.BoundsAreAvailable = False
 
-        #Saving the efficiencies of the different cuts
 
 
+    def openOneBranch(self, channelNumber):
+        df_temp = self.openedFile[self.channelNames[channelNumber]].arrays(library = "pd")
+        charge = pd.DataFrame(df_temp['WindowIntPE'].values.tolist())
+        time = pd.DataFrame(df_temp['SignalTimeCorrected'].values.tolist())
+        
+        #Calculate the max number of hits to form sensible column name
+        maxNbMatchedEvents = np.array(charge.shape)[1]
+        maxNbPeakEvents = np.array(time.shape)[1]
+        #matched events informations
+        names_windowIntPE=["matchedHit%i_WindowIntPE"%i for i in range(maxNbMatchedEvents)]
+        names_TOF=["matchedHit%i_TOF"%i for i in range(maxNbMatchedEvents)]
+        names_WindowUpperBound = ["matchedHit%i_WindowUpperTime"%i for i in range(maxNbMatchedEvents)]
+        names_WindowLowerBound = ["matchedHit%i_WindowLowerTime"%i for i in range(maxNbMatchedEvents)]
+        names_WindowCentralTime = ["matchedHit%i_WindowCentralTime"%i for i in range(maxNbMatchedEvents)]
+        names_WindowCentralTimeCorrected = ["matchedHit%i_WindowCentralTimeCorrected"%i for i in range(maxNbMatchedEvents)]
+
+        #peak information
+        names_IntPE=["peakHit%i_IntPE"%i for i in range(maxNbPeakEvents)]
+        names_IntCharge=["peakHit%i_IntCharge"%i for i in range(maxNbPeakEvents)]
+        names_SignalTimeCorrected=["peakHit%i_SignalTimeCorrected"%i for i in range(maxNbPeakEvents)]
+        
+        
+
+        
+        #Have a new column for TOF that will be filled either with the matched hit times or a flag at -9999
+        #if the matching did not happen
+        if 'SignalTimeMatchedTOF1' in df_temp.columns:
+            print("SignalTimeMatched is available, using it to compute TOF")
+            TOF = pd.DataFrame((ak.Array(df_temp['SignalTimeMatchedTOF1'].values.tolist())-ak.Array(df_temp['SignalTimeMatchedTOF0'].values.tolist())).tolist(), columns=names_TOF)
+        
+        else:
+            print("SignalTimeMatched is not available, TOF will be set to %i"%self.flag)
+            TOF = pd.DataFrame((df_temp['WindowIntPE']).values.tolist(), columns=names_TOF)
+            for col in TOF.columns:
+                TOF[col].values[:] = self.flag
+
+        WindowIntPE = pd.DataFrame(df_temp['WindowIntPE'].values.tolist(), columns = names_windowIntPE)
+
+        #peak information
+        IntPE = pd.DataFrame(df_temp['IntPE'].values.tolist(), columns = names_IntPE)
+        IntCharge = pd.DataFrame(df_temp['IntCharge'].values.tolist(), columns = names_IntCharge)
+        SignalTimeCorrected = pd.DataFrame(df_temp['SignalTimeCorrected'].values.tolist(), columns = names_SignalTimeCorrected)
+
+        #if we have information about the bounds
+        if "WindowUpperTime" in df_temp.columns:
+            self.BoundsAreAvailable = True
+            WindowUpperBound = pd.DataFrame(df_temp['WindowUpperTime'].values.tolist(), columns = names_WindowUpperBound)
+            WindowLowerBound = pd.DataFrame(df_temp['WindowLowerTime'].values.tolist(), columns = names_WindowLowerBound)
+            WindowCentralTime = pd.DataFrame(df_temp['WindowCentralTime'].values.tolist(), columns = names_WindowCentralTime)
+            WindowCentralTimeCorrected = pd.DataFrame(df_temp['WindowCentralTimeCorrected'].values.tolist(), columns = names_WindowCentralTimeCorrected)
+
+            df_temp = pd.concat([df_temp, WindowUpperBound], axis = 1)
+            df_temp = pd.concat([df_temp, WindowLowerBound], axis = 1)
+            df_temp = pd.concat([df_temp, WindowCentralTime], axis = 1)
+            df_temp = pd.concat([df_temp, WindowCentralTimeCorrected], axis = 1)
+
+    
+    
+        df_temp = pd.concat([df_temp, WindowIntPE], axis = 1)
+        df_temp = pd.concat([df_temp, TOF], axis =1)
+        df_temp = pd.concat([df_temp, IntPE], axis = 1)
+        df_temp = pd.concat([df_temp, IntCharge], axis = 1)
+        df_temp = pd.concat([df_temp, SignalTimeCorrected], axis =1)
 
 
+        return df_temp
 
     def openDataFile(self):
         #only open the file once
         if self.openedFile is None:
             print("Opening the data root file: %s"%self.dataFile)
             self.openedFile = ur.open(self.dataFile)
-            for channelNumber in range(len(channelNames)):
+            availableChannels = [channel[:-2] for channel in self.openedFile.keys()]
+            for channelNumber in range(len(self.channelNames)):
                 print(f"Reading channel {self.channelNames[channelNumber]}...")
-                df_temp = self.openedFile[self.channelNames[channelNumber]].arrays(library = "pd")
-                charge = pd.DataFrame(df_temp['WindowIntPE'].values.tolist())
-                time = pd.DataFrame(df_temp['SignalTimeCorrected'].values.tolist())
-                df_charge = pd.concat([df_temp, charge], axis =1)
-                df_time = pd.concat([df_temp, time], axis = 1)
+                if self.channelNames[channelNumber] in availableChannels:
+                    df_temp = self.openOneBranch(channelNumber)
+                    self.arrayData.append(df_temp)
 
-                self.arrayDataFramesCharge.append(df_charge)
-                self.arrayDataFramesTime.append(df_time)
-                print(f" ... done", end = "", flush=True)
+                    print(f"... done\n", end = "", flush=True)
+                else:
+                    #instead make a copy of the previous branch and set everything 
+                    #to a flag value
+                    df_temp = self.openOneBranch(channelNumber-1) * 0 + -9999
+                    self.arrayData.append(df_temp)
+                    print(f"... skipping channel")
         else:
             raise Exception("The file already seems to be open.")
 
+    
+    def getDataFrameAllDetectors(self):
+        print("The data has ", len(self.arrayData),"entries which hold the following column in the dataframe: ", self.arrayData[0].columns)
+        return self.arrayData
+    
+    def getDataFrameDetector(self, detectorID):
+        print("Returning the data frame for detector %i: %s"%(detectorID, self.channelNames[detectorID]))
+        return self.arrayData[detectorID]
+    
+    def getColumnDataFrameDetector(self, branch_name, detectorID):
+        print("Returning the column %s in the data frame for detector %i: %s"%(branch_name, detectorID, self.channelNames[detectorID]))
+        return self.arrayData[detectorID][branch_name]
+    
+    def addBranchToDataFrameDetector(self, new_branch_name, detectorID, value):
+        print("Adding the branch %s to the data frame for detector %i: %s"%(new_branch_name,detectorID, self.channelNames[detectorID]))
+        self.arrayData[detectorID][new_branch_name] = value
+        return 0 
+    
+    def addBranchToAllDetectors(self, new_branch_name, value):
+        print("Adding the branch %s to the data frame for  all detectors"%(new_branch_name))
+        for i in range(len(self.arrayData)):
+            self.arrayData[i][new_branch_name] = value
+        return 0 
+    
+    def addOperationBranchToAllDetectors(self, new_branch_name,  branch1_name, operation, branch2_name):
+        for detectorID in np.arange(0, len(self.arrayData), 1):
+            if operation=="+":
+                res = self.getColumnDataFrameDetector(branch1_name, detectorID) + self.getColumnDataFrameDetector(branch2_name, detectorID)
+            elif operation == '-':
+                res = self.getColumnDataFrameDetector(branch1_name, detectorID) - self.getColumnDataFrameDetector(branch2_name, detectorID)
+            elif operation == '*':
+                res = self.getColumnDataFrameDetector(branch1_name, detectorID) * self.getColumnDataFrameDetector(branch2_name, detectorID)
+            elif operation == '/':
+                res = self.getColumnDataFrameDetector(branch1_name, detectorID) / self.getColumnDataFrameDetector(branch2_name, detectorID)
+            else:
+                raise Exception("Wrong operator, use '+' or '-' or '*' or '/' please.")
+            self.addBranchToDataFrameDetector(new_branch_name, detectorID, res)
+
+    
+    
+    # def plot2dHist(self, x, y):
+    
+    def plotHist1DfromData(self, array_columns, targetDetectors, plot_saving, normalise = False, MinBound = None, MaxBound = None, additionalLabel = None, yscale=None, nMaxColumns = 4, nbBins = 100, statsBin= False):
+        print("Plotting 1D histogram of columns: ", array_columns, " normalisation is set to: ", normalise)
+        fig, ax = plt.subplots(max(1, math.ceil(len(targetDetectors)/nMaxColumns)), nMaxColumns, figsize = (16, 9))
+        range_min = []
+        range_max = []
+        binwidth = []
+
+        if MinBound!=None:
+            #in case we gave an int
+            if type(MinBound) == int or type(MinBound) == float:
+                MinBound = [MinBound for i in range(len(targetDetectors))]
+            #in case we gave an array of the wrong size
+            elif len(MinBound) != len(targetDetectors):
+                print("\nWarning: you have not given the correct number of min Bounds, asusming some of them")
+                MinBound = [MinBound[0] for i in range(len(targetDetectors))]
+
+        if MaxBound!=None:
+            #in case we gave an int
+            if type(MaxBound) == int or type(MaxBound) == float:
+                MaxBound = [MaxBound for i in range(len(targetDetectors))]
+            #in case we gave an array of the wrong size
+            elif len(MaxBound) != len(targetDetectors):
+                print("\nWarning: you have not given the correct number of Max Bounds, asusming some of them")
+                MaxBound = [MaxBound[0] for i in range(len(targetDetectors))]
+
+        for variableID, column in enumerate(array_columns):
+            #label the plot depending on the column we are looking at
+            if (column.find('Time') != -1):
+                xaxis_label = 'Time (ns)'
+            elif (column.find('TOF') != -1):
+                xaxis_label = 'Time of Flight (ns)'
+            elif (column.find('PE') != -1):
+                xaxis_label = 'Charge (PE)'
+            else:
+                xaxis_label = column
+            for indexInTargetDetector, channelID in enumerate(targetDetectors):
+                #channelID is the detector of interest, indexInTargetDetector is only for detectors we
+                #want to plot
+                if (variableID == 0):
+                    #so the same variables will have the same bins 
+                    if MinBound == None:
+                        possible_min = min(self.arrayData[channelID][column]) * 0.8
+                        if np.isnan(possible_min) or min(self.arrayData[channelID][column]) == -9999:
+                            possible_min = -1
+
+                        range_min.append(possible_min)
+                    else:
+                        possible_min = max(MinBound[indexInTargetDetector],min(self.arrayData[channelID][column]) * 0.8)
+                        range_min.append(possible_min)
+                    
+
+                    if MaxBound == None:
+                        possible_max = max(self.arrayData[channelID][column]) * 1.2
+                        if np.isnan(possible_max) or max(self.arrayData[channelID][column]) == -9999:
+                            possible_max = possible_min + 2
+                        range_max.append(possible_max)
+                    else:
+                        range_max.append(min(MaxBound[indexInTargetDetector], max(self.arrayData[channelID][column]) * 1.2))
+
+                    
+
+                    binwidth.append((range_max[-1]-range_min[-1])/nbBins)
+
+                if len(targetDetectors) == 1:
+                    axis = ax
+                elif len(targetDetectors)>nMaxColumns:
+                    #if we have multiple subplots: need to put into correct one
+                    plot_row = math.floor(indexInTargetDetector/nMaxColumns)
+                    plot_column = indexInTargetDetector - (plot_row * nMaxColumns)
+
+                    axis = ax[plot_row, plot_column]
+                else:
+                    axis = ax[indexInTargetDetector]
+
+                if statsBin:
+                    label = "%s: %i entries\n Mean: %.2f Std: %.2f"%(column, len(self.arrayData[channelID][column]), self.arrayData[channelID][column].mean(), self.arrayData[channelID][column].std())
+                else:
+                    label = "%s: %i entries"%(column, len(self.arrayData[channelID][column]))
+                
+                axis.hist(self.arrayData[channelID][column], bins = nbBins, range = (range_min[indexInTargetDetector], range_max[indexInTargetDetector]), label = label, density=normalise, histtype="step")
+        #cosmetics titles etcs
+        for indexInTargetDetector, channelID in enumerate(targetDetectors):
+            if len(targetDetectors) == 1:
+                axis = ax
+            elif len(targetDetectors)>nMaxColumns:
+                    plot_row = math.floor(indexInTargetDetector/nMaxColumns)
+                    plot_column = indexInTargetDetector - (plot_row * nMaxColumns)
+                    axis = ax[plot_row, plot_column]
+            else:
+                axis = ax[indexInTargetDetector]
+            
+            if yscale == 'log':
+                axis.set_yscale('log')
+                axis.set_ylim([0.5, None])
+            
+            if nMaxColumns >= len(targetDetectors):
+                axis.legend(fontsize = 15)
+            else:
+                axis.legend(fontsize = 10)
+            axis.set_title("%s"%(self.channelNames[channelID]), fontsize = 18, weight = "bold")
+            axis.set_xlabel("%s"%xaxis_label, fontsize = 18)
+            if binwidth[indexInTargetDetector] > 10e3:
+                axis.set_ylabel("Occurences/%.3e"%(binwidth[indexInTargetDetector]), fontsize = 18)
+            if binwidth[indexInTargetDetector] > 1:
+                axis.set_ylabel("Occurences/%.1f"%(binwidth[indexInTargetDetector]), fontsize = 18)
+            elif binwidth[indexInTargetDetector] > 0.1:
+                axis.set_ylabel("Occurences/%.2f"%(binwidth[indexInTargetDetector]), fontsize = 18)
+            elif binwidth[indexInTargetDetector] > 0.01:
+                axis.set_ylabel("Occurences/%.3f"%(binwidth[indexInTargetDetector]), fontsize = 18)
+            elif binwidth[indexInTargetDetector] > 0.001:
+                axis.set_ylabel("Occurences/%.3e"%(binwidth[indexInTargetDetector]), fontsize = 18)
+            axis.grid()
+
+        if normalise:
+            fig.suptitle('WCTE Beamtest - Run %i, p = %i MeV/c n = %s - density \n%s'%(self.runNumber, self.runMomentum, self.runRefractiveIndex, additionalLabel), fontsize=18, weight ='bold')
+        else:
+            fig.suptitle('WCTE Beamtest - Run %i, p = %i MeV/c \n%s'%(self.runNumber, self.runMomentum, additionalLabel), fontsize=18, weight ='bold')
+        plt.tight_layout()
+        plt.savefig("../new_png_results/%s_Run%i.png"%(plot_saving, self.runNumber))
+        plt.savefig("../new_pdf_results/%s_Run%i.pdf"%(plot_saving, self.runNumber))
+        
+
+    def plotAllHist1DfromData(self, array_columns, plot_saving, normalise = False, MinBound = None, MaxBound = None, additionalLabel = None, yscale = None, nMaxColumns = 4, nbBins = 100):
+        targetDetectors = range(len(self.arrayData))
+        self.plotHist1DfromData(array_columns, targetDetectors, plot_saving, normalise, MinBound, MaxBound, additionalLabel, yscale, nMaxColumns, nbBins)
+    
+    def plotSomeDetectorHist1DfromData(self, array_columns, targetDetectors, plot_saving,  normalise = False, MinBound = None, MaxBound = None, additionalLabel = None, yscale = None, nMaxColumns = 4, nbBins = 100, statsBin = False):
+        #if we only want to plot a few detectors
+        if len(targetDetectors)<=4:
+            nMaxColumns = len(targetDetectors)
+        print(nMaxColumns)
+        self.plotHist1DfromData(array_columns, targetDetectors, plot_saving, normalise, MinBound, MaxBound, additionalLabel, yscale, nMaxColumns, nbBins, statsBin)
+
+    def plot2DScatterFromBranches(self, detector_x,  branch_name_x, detector_y, branch_name_y, detector_z = None, branch_name_z = None, units_x = "", units_y = "", units_z = "", additionalLabel = None, logz = False):
+        fig, ax = plt.subplots(1, 1, figsize = (16, 9))
+        x = self.arrayData[detector_x][branch_name_x]
+        y = self.arrayData[detector_y][branch_name_y]
+
+        range = [[max(x.mean()*0.6, min(x)*0.8), max(x)*1.04], [min(y)*0.8, max(y)*1.02]]
+        if logz:
+            hist = ax.scatter(x, y, c= self.arrayData[detector_z][branch_name_z], s = 3, norm = 'log', cmap = "viridis")
+        else:
+            hist = ax.scatter(x, y, c= self.arrayData[detector_z][branch_name_z],s = 3,  cmap = "viridis")
+
+        fig.colorbar(hist, ax=ax, label = '%s %s %s'%(self.channelNames[detector_z],branch_name_z, units_z))
+        ax.legend()
+        ax.grid()
+        # ax.set_xlim(range[0])
+        # ax.set_ylim(range[1])
+        ax.set_xlabel("%s %s %s"%(self.channelNames[detector_x], branch_name_x, units_x), fontsize=18)
+        ax.set_ylabel("%s %s %s"%(self.channelNames[detector_y], branch_name_y, units_y), fontsize=18)
+        fig.suptitle('WCTE Beamtest - Run %i, p = %i MeV/c n = %s\n%s'%(self.runNumber, self.runMomentum, self.runRefractiveIndex, additionalLabel), fontsize=18, weight ='bold')
+        plt.savefig("../new_png_results/Scatter_%s_%s_Run%i_viridis.png"%(self.channelNames[detector_z],branch_name_z, self.runNumber))
+        plt.savefig("../new_pdf_results/Scatter_%s_%s_Run%i_viridis.pdf"%(self.channelNames[detector_z], branch_name_z, self.runNumber))
+
+    def plot2DHistFromBranches(self, detector_x,  branch_name_x, detector_y, branch_name_y, units_x = "", units_y = "", additionalLabel = None, logz = False, bins = [100, 100], range = None):
+        fig, ax = plt.subplots(1, 1, figsize = (16, 9))
+        x = self.arrayData[detector_x][branch_name_x]
+        y = self.arrayData[detector_y][branch_name_y]
+
+        if range == None:
+            range = [[max(x.mean()*0.6, min(x)*0.8), max(x)*1.04], [min(y)*0.8, max(y)*1.02]]
+        
+        if logz:
+            hist = ax.hist2d(x, y, bins = bins, norm = 'log', range = range, cmap = "viridis")
+        else:
+            hist = ax.hist2d(x, y, bins = bins, range = range, cmap = "viridis")
+
+        clb = fig.colorbar(hist[3], ax=ax)
+        clb.ax.set_title(label = 'Occurences/%.2f %s %.2f %s'%((range[0][1]-range[0][0])/bins[0], units_x, (range[1][1]-range[1][0])/bins[1], units_y), fontsize=18)
+        # ax.legend()
+        ax.grid()
+        ax.set_xlim(range[0])
+        ax.set_ylim(range[1])
+        ax.set_xlabel("%s %s %s"%(self.channelNames[detector_x], branch_name_x, units_x), fontsize=18)
+        ax.set_ylabel("%s %s %s"%(self.channelNames[detector_y], branch_name_y, units_y), fontsize=18)
+        fig.suptitle('WCTE Beamtest - Run %i, p = %i MeV/c n = %s\n%s'%(self.runNumber, self.runMomentum, self.runRefractiveIndex, additionalLabel), fontsize=18, weight ='bold')
+        plt.savefig("../new_png_results/Hist2d_%s%s_%s%s_Run%i_viridis.png"%(self.channelNames[detector_x],branch_name_x, self.channelNames[detector_y],branch_name_y, self.runNumber))
+        plt.savefig("../new_png_results/Hist2d_%s%s_%s%s_Run%i_viridis.pdf"%(self.channelNames[detector_x],branch_name_x, self.channelNames[detector_y],branch_name_y, self.runNumber))
+
+
+    def getAcceptancenCoincidenceCut(self):
+        return sum(self.nCoincidenceSelectionPassed)/len(self.nCoincidenceSelectionPassed)
+
     def nCoincidenceSelection(self):
-        print()
         if self.openedFile is None:
-            openDataFile(self)
+            self.openDataFile(self)
 
         #only if we want the nCoincidenceSelection
-        if self.nCoincidenceSelectionBool :
-            print(f"Performing nCoincidenceSelection with n = {self.nCoincidenceSelectionValue} ...")
+        if self.nCoincidenceSelectionBool and "SignalTimeMatchedTOF1" in self.arrayData[0].columns:
+            print(f"Performing nCoincidenceSelection with n = {self.nCoincidenceSelectionValue} for run {self.runNumber}...")
             #the branches SignalTimeMatchedTOF1/0 have the format of the coincidence, we can just have a
             #read over them in one detector to have the general selection
-            self.nCoincidenceSelectionPassed = self.arrayDataFramesCharge[0]["SignalTimeMatchedTOF1"].map(len)==self.nCoincidenceSelectionValue
+            self.nCoincidenceSelectionPassed = self.arrayData[0]["SignalTimeMatchedTOF1"].map(len)==self.nCoincidenceSelectionValue
+            self.applyCut(self.nCoincidenceSelectionPassed)
+        
+        elif self.nCoincidenceSelectionBool:
+            print("\nCannot perform a selection on the number of coincidence found: no coincidence was processed for this file, please make sure that the branch SignalTimeMatchedTOF1 (and0) exists in the dataframe, might need to change the config_(no)Hodoscope.json...\n")
+            #this will always be true, but it is usefulme sure keep the same output
+            # self.nCoincidenceSelectionPassed = self.arrayData[0]["DigitimingOffset"]!= -9998
+            # self.applyCut(self.nCoincidenceSelectionPassed)
 
         else:
              print(f"In the config file, checking the coincidence is set to {self.nCoincidenceSelectionBool}, we are therefore not processing the change", end="", flush=True)
-             self.nCoincidenceSelectionPassed =
+            #  self.nCoincidenceSelectionPassed = self.arrayData[0]["DigitimingOffset"]!= -9998
+
+    def applyCut(self, cut_boolean):
+        print("... this cut keeps %i events (%.2f percent), relative to df before this cut\n"%(sum(cut_boolean), sum(cut_boolean)/len(cut_boolean) * 100))
+        for i in range(len(self.arrayData)):
+            self.arrayData[i] = self.arrayData[i][cut_boolean]
+        return self.arrayData
+
+    def getBranchList(self, detectorID):
+        return self.arrayData[detectorID].columns
+    
+    def selectBasedOnCondition(self, detectorID, branch_name, operation, value):
+        print(f"Performing condition based selection, keeping {self.channelNames[detectorID]} {branch_name} {operation} {value}...")
+        if operation == ">=":
+            passedSelection = self.arrayData[detectorID][branch_name] >= value
+        if operation == ">":
+            passedSelection = self.arrayData[detectorID][branch_name] > value
+        if operation == "<":
+            passedSelection = self.arrayData[detectorID][branch_name] < value
+        if operation == "==":
+            passedSelection = self.arrayData[detectorID][branch_name] == value
+        self.applyCut(passedSelection)
 
 
 
 
-    for channelNumber in range(len(channelNames)):
-                self.arrayDataFramesCharge[channelNumber] =
+            
+
+    #
+    # for channelNumber in range(len(channelNames)):
+    #             self.arrayDataCharge[channelNumber] =
 
 
 

--- a/python/lowMomentum_analysis.py
+++ b/python/lowMomentum_analysis.py
@@ -1,0 +1,97 @@
+#This is the helper code doing the particleID_final analysis, class based instead of the previous messy multiple functions approach
+
+import uproot as ur
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import sys
+
+
+class LowMomentumAnalysis:
+    "This class sets up the analysis tools for the low momentum set-up"
+    def __init__(self, config):
+        self.channelNames = config["channelNames"]
+        self.dataFile = config["dataFile"]
+        self.runNumber = config["runNumber"]
+        self.runMomentum = config["runMomentum"]
+        self.runRefractiveIndex = config["runRefractiveIndex"]
+        self.referenceSelectionCutFile = config["referenceSelectionCutFile"]
+        self.batchMode = config["batchMode"]
+        self.saveRootFile = config["saveRootFile"]
+
+        #Selection of events based on the number of coincident hits
+        self.nCoincidenceSelectionBool = config["nCoincidenceSelectionBool"]
+        self.nCoincidenceSelectionValue = config["nCoincidenceSelectionValue"]
+
+        #Selection of events based on the dE/dx of particles in the trigger scintillator
+        self.triggerScintillatorSelectionBool = config["triggerScintillatorSelection"]
+        self.triggerScintillatorSelectionValue = config["triggerScintillatorSelectionValue"]
+
+
+        self.openedFile = None
+        #looking only at the window integrated charge
+        #arrays holding the dataframes
+        self.arrayDataFramesCharge = []
+        self.arrayDataFramesTime = []
+
+        #Good event selection, by default
+        self.nCoincidenceSelectionPassed = None
+        self.triggerScintillatorSelectionPassed = None
+
+
+        #Saving the efficiencies of the different cuts
+
+
+
+
+
+    def openDataFile(self):
+        #only open the file once
+        if self.openedFile is None:
+            print("Opening the data root file: %s"%self.dataFile)
+            self.openedFile = ur.open(self.dataFile)
+            for channelNumber in range(len(channelNames)):
+                print(f"Reading channel {self.channelNames[channelNumber]}...")
+                df_temp = self.openedFile[self.channelNames[channelNumber]].arrays(library = "pd")
+                charge = pd.DataFrame(df_temp['WindowIntPE'].values.tolist())
+                time = pd.DataFrame(df_temp['SignalTimeCorrected'].values.tolist())
+                df_charge = pd.concat([df_temp, charge], axis =1)
+                df_time = pd.concat([df_temp, time], axis = 1)
+
+                self.arrayDataFramesCharge.append(df_charge)
+                self.arrayDataFramesTime.append(df_time)
+                print(f" ... done", end = "", flush=True)
+        else:
+            raise Exception("The file already seems to be open.")
+
+    def nCoincidenceSelection(self):
+        print()
+        if self.openedFile is None:
+            openDataFile(self)
+
+        #only if we want the nCoincidenceSelection
+        if self.nCoincidenceSelectionBool :
+            print(f"Performing nCoincidenceSelection with n = {self.nCoincidenceSelectionValue} ...")
+            #the branches SignalTimeMatchedTOF1/0 have the format of the coincidence, we can just have a
+            #read over them in one detector to have the general selection
+            self.nCoincidenceSelectionPassed = self.arrayDataFramesCharge[0]["SignalTimeMatchedTOF1"].map(len)==self.nCoincidenceSelectionValue
+
+        else:
+             print(f"In the config file, checking the coincidence is set to {self.nCoincidenceSelectionBool}, we are therefore not processing the change", end="", flush=True)
+             self.nCoincidenceSelectionPassed =
+
+
+
+
+    for channelNumber in range(len(channelNames)):
+                self.arrayDataFramesCharge[channelNumber] =
+
+
+
+
+
+
+
+
+
+

--- a/python/new_analysis/process_ac_waveform_analysis.py
+++ b/python/new_analysis/process_ac_waveform_analysis.py
@@ -250,7 +250,7 @@ def process_batch(waveforms, optional_branches, channel, output_file, config_arg
 
 
     else:
-        # print(len(window_integrated_charges[:]), len(SignalTimeMatchedTOF1[:]))
+        print(len(window_integrated_charges[:]), len(SignalTimeMatchedTOF1[:]))
         window_peaks = ak.zip({"WindowIntCharge": window_integrated_charges,
                             "WindowIntPE": window_integrated_pe,
                             "SignalTimeMatchedTOF1": SignalTimeMatchedTOF1,

--- a/python/new_analysis/process_ac_waveform_analysis.py
+++ b/python/new_analysis/process_ac_waveform_analysis.py
@@ -19,6 +19,20 @@ import matplotlib.pyplot as plt
 
 import coincidence as coincidence
 
+def compare_lengths(arr1, arr2):
+            """
+            Recursively prints the lengths of nested arrays within an Awkward Array.
+            """
+            i = 0
+            while len(arr1[i]) == len(arr2[i]) and i<len(arr1)-1:
+                i+=1
+            if i==len(arr1)-1:
+                print("same dimensions!")
+                return 0
+            else:
+                print("Dimension of array 1:", len(arr1[i]), "Dimension of array 2:",len(arr2[i]))
+                print("Failed at %.1f percent i= %i"%(i/len(arr1)*100, i))
+                return i
 
 
 def print_usage(argv):
@@ -28,10 +42,16 @@ def print_usage(argv):
     print(f"    input_ntuple_file one root file which contains multi-peak info")
     print(f"    config_file: config JSON file")
     print(f"    output_file: output ntuple root file")
+    print(f"    ")
+    print(f"    If you are having issues, try to swith on the debug variable in the process_ac_waveform_analysis.py code")
     return
 
 
 def process_waveforms(argv):
+
+    global debug 
+    debug = False #some potentially useful print outs
+
     if len(argv) < 4:
         print("Not enough arguments provided.")
         print_usage(argv)
@@ -41,6 +61,7 @@ def process_waveforms(argv):
     ntuple_filename = argv[2]
     config_filename = argv[-2]
     output_filename = argv[-1]
+
 
 
     print(f"Using config file {config_filename}")
@@ -55,6 +76,8 @@ def process_waveforms(argv):
 
 #
 def process_file(root_filename, ntuple_filename, config, output_file):
+
+    
     print(f"Processing root file {root_filename}\n")
 #     "open the root file"
     run_file = ur.open(root_filename)
@@ -68,15 +91,13 @@ def process_file(root_filename, ntuple_filename, config, output_file):
     #TODO: make check coincidence and the PMTs used part of the config file (and merge the config files)
     print("You have chosen to set the CheckCoincidence to", checkCoincidence)
     if (checkCoincidence):
-        print("The PMTs used for the main coincidence are %i and %i and the PMT used for loose coincidence is %i \n"%(mainCoincidencePMTa, mainCoincidencePMTb, looseCoincidencePMT))
+        print("The PMTs used for the first coincidence are %i and %i and the PMT used for second coincidence is %i (loose or tight depends on set-up) \n"%(mainCoincidencePMTa, mainCoincidencePMTb, looseCoincidencePMT))
 
-    signalTimeBranch = "SignalTimeCorrected" #eventually we should move to SignalTimeCorrected
+    signalTimeBranch = "SignalTimeCorrected"
+    run_number = int(root_filename[-11:-5])
 
     if not(checkCoincidence):
-        #reding the timings for calibration, technically we shouldn't need following Arturo's
-        #modifications but good sanity check
-
-
+        #reding the timings for calibration, technically we shouldn't need following Arturo's modifications but good sanity check
         #for a narrower integration window but because the integration is made with respect to the actual
         #waveforms it doesn't work well for now, we would have to apply the timing corrections there
         #I don't think that it is a big deal because the window is set quite large so it does capture all the signal, even if it uses the old timing.
@@ -97,17 +118,22 @@ def process_file(root_filename, ntuple_filename, config, output_file):
         hit_times = pd.DataFrame(df_TOF13['%s'%signalTimeBranch].values.tolist())
         df_TOF13 =  pd.concat([df_TOF13, hit_times], axis=1)
 
-        print(df_TOF1_hitTimes)
+        # print(df_TOF1_hitTimes)
 
     else: #look at the coincidence
         #now instead check the coincidence
         #the order will depend on the ones you choose, be careful
         #By default we take the coincidence between two PMTs in TOF1 and loosely match it with another PMT in TOF0,
         #TODO: make this coincidence accross all PMTs (increase efficiency)
-        SignalTimeMatchedTOF1, SignalTimeMatchedTOF0 = coincidence.checkCoincidence(ntuple_filename, mainCoincidencePMTa, mainCoincidencePMTb, looseCoincidencePMT)
+        #we have tight-loose coincidence for TOF1-TOF0 in LM setup
+        #and tight-tight in TG run, can change default first_hodoscope_run
+        #in coincidence.performCoincidence
+        SignalTimeMatchedTOF1, SignalTimeMatchedTOF0 = coincidence.performCoincidence(ntuple_filename, mainCoincidencePMTa, mainCoincidencePMTb, looseCoincidencePMT, run_number)
         #set the reference timing for the hits as the time matched dataframe
         df_TOF1_hitTimes = SignalTimeMatchedTOF1.copy()
         max_column_labels = df_TOF1_hitTimes.idxmax(axis=1, skipna=True)
+        #need to have the same format to calculate the TOF when computing the position of the window
+        df_TOF0_hitTimes = SignalTimeMatchedTOF0.copy()
         #some events will not see any data
         max_column_labels = np.where(np.isnan(max_column_labels), 0, max_column_labels)
 
@@ -130,6 +156,7 @@ def process_file(root_filename, ntuple_filename, config, output_file):
             digitizer_channels[digitizer][f"{channel}"] = i
         print(f"Channel number {i}: {digitizer}/{channel} is {'active' if config['ActiveChannels'][i] else 'not active'}")
     active_digitizers = [d for d in digitizers if len(digitizer_channels[d]) > 0]
+    print("active_digitisers", active_digitizers)
     events_per_digitizer = [run_file[d].num_entries for d in active_digitizers]
     if min(events_per_digitizer) != max(events_per_digitizer):
         raise ValueError("Digitizers wth active channels have different numbers of events: " +
@@ -143,7 +170,7 @@ def process_file(root_filename, ntuple_filename, config, output_file):
     print(f"All {n_channels} active channels have {n_events} events")
 
     #we need to perform the calibration of the timing for the window offset
-    run_number = int(root_filename[-11:-5])
+    
     for d in active_digitizers:
         optional_branch_names = [b for b in ["timeStamp", "triggerTime", "spillNumber"] if b in run_file[d].keys()]
         channels = digitizer_channels[d]
@@ -153,18 +180,26 @@ def process_file(root_filename, ntuple_filename, config, output_file):
             print(f"... events {report.tree_entry_start} to {report.tree_entry_stop}")
             for c, i in channels.items():
                 print(f"... ... processing {d}/{c} into {config['ChannelNames'][i]}", end="", flush=True)
+                print("\nWindow integration bounds are: [%.1f, %.1f] and the timing branch considered is %s. Coincidence check is %s\n"%(config["window_lower_bound"][i], config["window_upper_bound"][i], signalTimeBranch, checkCoincidence))
                 #calculate the time offset to the reference
                 df = ref_file[config['ChannelNames'][i]].arrays(library="pd")
                 hit_times = pd.DataFrame(df['%s'%signalTimeBranch].values.tolist())
                 #absolute hit time offset
                 df =  pd.concat([df, hit_times], axis=1)
                 if not(checkCoincidence):
-                    #the wire length calibration that need to be made is the mean of the difference between the PMTs hit time and the TOF1 mean hit time (taking the earliest hit)
+                    #the wire length calibration that need to be made is the mean of the difference between the PMTs hit time and the TOF1 
+                    #mean hit time (taking the earliest hit)
                     WindowTimeOffset = (df[0]-(df_TOF1_hitTimes[0]+df_TOF11[0]+df_TOF12[0]+df_TOF13[0])/4).mean()
 
                 else:
                     #If there is coincidence, no need to offset, aligment has been done by Arturo's timing corrections
-                    WindowTimeOffset = 0 #(df[0] - SignalTimeMatchedTOF1[0]).mean()
+                    #We still remove the mean of the offset
+                    #with some discretisation to make sure we are where we should be 
+                    
+                    WindowTimeOffset = (df[0]-df_TOF1_hitTimes[0]).mean()
+
+                    #Here, the expected time offset is proportional to the particle travel time 
+                    #(df[0] - SignalTimeMatchedTOF1[0]).mean()
 
                 config_args = {
                     "threshold": config["Thresholds"][i],
@@ -177,30 +212,37 @@ def process_file(root_filename, ntuple_filename, config, output_file):
                     "PMTgain": config["PMTgain"][i],
                     "window_lower_bound": config["window_lower_bound"][i],
                     "window_upper_bound": config["window_upper_bound"][i],
+                    "PMTdistanceToTOF1": config["PMTLocRelativeToTOF1"][i],
+                    "distanceTOF1toTOF0": config["distanceTOF1toTOF0"],
+                    "checkCoincidence": config["checkCoincidence"]
                 }
                 waveforms = batch[c]
                 optional_branches = {b: batch[b] for b in optional_branch_names}
 
                 if not(checkCoincidence):
-                    process_batch(waveforms, optional_branches, config["ChannelNames"][i], output_file, config_args, df_TOF1_hitTimes.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1], df.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1])
+                    process_batch(waveforms, optional_branches, config["ChannelNames"][i], output_file, config_args, df_TOF1_hitTimes.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1], df.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1],config["window_lower_bound"][i], config["window_upper_bound"][i])
 
                 if checkCoincidence:
                     #reshape the timing entires so we can save them with the data
                     SignalTimeMatchedTOF0_reduced = np.array(SignalTimeMatchedTOF0.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1].values.squeeze().tolist())
-                    #TODO get more than 1 hit !!
-                    SignalTimeMatchedTOF0_reduced  = ak.Array([[val for val in values if (not np.isnan(val))] for values in SignalTimeMatchedTOF0_reduced])
-                    # SignalTimeMatchedTOF0 = ak.Array([[values] for values in SignalTimeMatchedTOF0])
 
                     SignalTimeMatchedTOF1_reduced  = np.array(SignalTimeMatchedTOF1.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1].values.squeeze().tolist())
-                    SignalTimeMatchedTOF1_reduced
 
-                    SignalTimeMatchedTOF1_reduced  = ak.Array([[val for val in values if (not np.isnan(val))] for values in SignalTimeMatchedTOF1_reduced])
-                    # SignalTimeMatchedTOF1 = ak.Array([[values] for values in SignalTimeMatchedTOF1])
-
-
-                    process_batch(waveforms, optional_branches, config["ChannelNames"][i], output_file, config_args, df_TOF1_hitTimes.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1], df.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1], SignalTimeMatchedTOF1_reduced, SignalTimeMatchedTOF0_reduced)
+                    #match the size of the dataframes to the size of the batch
+                    df_TOF1_hitTimes_reduced = df_TOF1_hitTimes.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1]
 
 
+                    df_TOF0_hitTimes_reduced = df_TOF0_hitTimes.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1]
+
+                    df_reduced = df.loc[int(report.tree_entry_start):int(report.tree_entry_stop)-1]
+
+
+                    SignalTimeMatchedTOF1_reduced = ak.Array([[val for val in SignalTimeMatchedTOF1_reduced[index] if (not np.isnan(val))] for index in range(len(SignalTimeMatchedTOF1_reduced))])
+
+                    SignalTimeMatchedTOF0_reduced = ak.Array([[val for val in SignalTimeMatchedTOF0_reduced[index] if (not np.isnan(val))] for index in range(len(SignalTimeMatchedTOF0_reduced))])
+
+
+                    process_batch(waveforms, optional_branches, config["ChannelNames"][i], output_file, config_args, df_TOF1_hitTimes_reduced, df_reduced,  config["window_lower_bound"][i], config["window_upper_bound"][i], df_TOF0_hitTimes_reduced, SignalTimeMatchedTOF1_reduced, SignalTimeMatchedTOF0_reduced)
 
     print(f"Saving event info for run {run_number}")
     output_file["EventInfo"] = {
@@ -224,16 +266,57 @@ def read_nTuple(df, branch_name, isSqueezed = False):
     return branch
 
 
-def process_batch(waveforms, optional_branches, channel, output_file, config_args, df_TOF1_hitTimes, df, SignalTimeMatchedTOF1 =None, SignalTimeMatchedTOF0 = None):
+def process_batch(waveforms, optional_branches, channel, output_file, config_args, df_TOF1_hitTimes, df, lower_bound, upper_bound, df_TOF0_hitTimes=None, SignalTimeMatchedTOF1 = None, SignalTimeMatchedTOF0 = None):
 
     waveform_analysis = WaveformAnalysis(waveforms, **config_args)
 
     #instead of overwriting the variables, copy them from the root file
     #TODO: impose coincidence and only perform the integration on peaks that have been matched
-    waveform_analysis.run_window_analysis(df_TOF1_hitTimes, df)
+    if checkCoincidence:
+
+        c =2.99792458 #ns/m
+        electronTravelTime = c * config_args["PMTdistanceToTOF1"]
+
+        #all particles are assumed to travel at speed c 
+        #but protons and others are slower, we need to take those into account
+        relativeTOF_offset = (df_TOF1_hitTimes - df_TOF0_hitTimes) * (config_args["PMTdistanceToTOF1"]/config_args["distanceTOF1toTOF0"]) - electronTravelTime
+
+        #add the TOF offset to the expected time, which will be diferent for each peak
+        for i in range(max(df_TOF1_hitTimes["nPeaks"])):
+            df_TOF1_hitTimes[i] = relativeTOF_offset[i] + df_TOF1_hitTimes[i]
+
+        waveform_analysis.run_window_analysis(df_TOF1_hitTimes, df)
+        ##calculate the time of the matched hits in the waveform
+        #only save for the TOF the hits that 
+        shifted_Hit_Time = SignalTimeMatchedTOF1 - df["DigiTimingOffset"] + config_args["window_time_offset"]
+
+        relativeTOF_offset_forTOFcalc = (SignalTimeMatchedTOF1 - SignalTimeMatchedTOF0) * (config_args["PMTdistanceToTOF1"]/config_args["distanceTOF1toTOF0"]) - electronTravelTime
+
+        shifted_Hit_Time_upper = shifted_Hit_Time + upper_bound + relativeTOF_offset_forTOFcalc
+        shifted_Hit_Time_lower = shifted_Hit_Time + lower_bound + relativeTOF_offset_forTOFcalc
+        
+        EndWaveform = waveform_analysis.waveformEnd
+        ns_per_sample = waveform_analysis.ns_per_sample
+        #we need at least part of the window to be included in the waveform
+        #We need at least one entry in the waveform to perform the  integration so we 
+        #are getting rid of all other entries in the matched timing by calculating if the expected timing is in it or not
+        isAtLeastPartlyWithinRange = np.where(shifted_Hit_Time_upper<ns_per_sample, False, np.where(shifted_Hit_Time_lower>(EndWaveform)*ns_per_sample, False, True))
+
+        SignalTimeMatchedTOF1 = SignalTimeMatchedTOF1[isAtLeastPartlyWithinRange]
+        SignalTimeMatchedTOF0 = SignalTimeMatchedTOF0[isAtLeastPartlyWithinRange]
+    else:
+        waveform_analysis.run_window_analysis(df_TOF1_hitTimes, df)
+    
+    
     #window integration which has to be done here as it uses the timing
     window_integrated_charges = waveform_analysis.window_int_charge
     window_integrated_pe = waveform_analysis.window_int_pe
+
+    window_width = waveform_analysis.windowWidth
+    window_lower_bound = waveform_analysis.windowIntLowerBound
+    window_upper_bound = waveform_analysis.windowIntUpperBound
+    window_central_time = waveform_analysis.windowIntCentralTime
+    window_central_time_corrected = waveform_analysis.windowIntCentralTimeCorrected
 
 
     peaks = ak.zip({"PeakVoltage": read_nTuple(df, "PeakVoltage", isSqueezed = False),
@@ -243,30 +326,76 @@ def process_batch(waveforms, optional_branches, channel, output_file, config_arg
                     "IntPE": read_nTuple(df, "IntPE", isSqueezed = False),
                     "SignalTimeCorrected": read_nTuple(df, "SignalTimeCorrected", isSqueezed = False)})
 
-    #needs to be handled separately because it has another format
+    #needs to be handled separately because it has another 
     if not(checkCoincidence):
         window_peaks = ak.zip({"WindowIntCharge": window_integrated_charges,
-                            "WindowIntPE": window_integrated_pe})
+                            "WindowIntPE": window_integrated_pe,
+                            "WindowLowerTime": window_lower_bound,
+                            "WindowUpperTime":
+                            window_upper_bound,
+                            "WindowCentralTime":
+                            window_central_time,
+                            "WindowCentralTimeCorrected":
+                            window_central_time_corrected})
+
+        #if we do not have TOF defined.
+        branches = {"Pedestal": read_nTuple(df, "Pedestal", isSqueezed = True),
+                    "PedestalSigma": read_nTuple(df, "PedestalSigma", isSqueezed = True),
+                    "MaxVoltage": read_nTuple(df, "MaxVoltage", isSqueezed = True),
+                    "WholeWaveformInt": read_nTuple(df, "WholeWaveformInt", isSqueezed = True),
+                    "DigiTimingOffset": read_nTuple(df, "DigiTimingOffset", isSqueezed = True),
+                    "Peaks": peaks,
+                    "WindowPeaks": window_peaks,
+                    **optional_branches}
 
 
     else:
-        print(len(window_integrated_charges[:]), len(SignalTimeMatchedTOF1[:]))
-        window_peaks = ak.zip({"WindowIntCharge": window_integrated_charges,
+        #trying to compare the shapes of the array to see where there are issues
+        if debug:
+            #somethimes we have some issued with the format, should not have them anymore 
+            #but just in case, useful to keep
+            print("Comparing the length of SignalTimeMatchedTOF0 and SignalTimeMatchedTOF1")
+            compare_lengths(SignalTimeMatchedTOF0, SignalTimeMatchedTOF1)
+            print("Comparing the length of SignalTimeMatchedTOF0 and window_width")
+            k = compare_lengths(SignalTimeMatchedTOF0, window_width)
+
+            print(shifted_Hit_Time_lower[k], shifted_Hit_Time_upper[k])
+
+            print(SignalTimeMatchedTOF1[k], window_width[k])
+            print("Comparing the length of window_width and window_integrated_charges")
+            compare_lengths(window_width, window_integrated_charges)
+
+            
+            print("Comparing the length of SignalTimeMatchedTOF1 and window_integrated_charges")
+            compare_lengths(SignalTimeMatchedTOF1, window_integrated_charges)
+
+        window_peaks = ak.zip({
+                            "WindowIntCharge": window_integrated_charges,
                             "WindowIntPE": window_integrated_pe,
+                            # "df_TOF1_hitTimes":df_TOF1_hitTimes,
+                            #"nPeaksMatched": df_TOF1_hitTimes["nPeaks"],
+                            "WindowWidth": window_width,
                             "SignalTimeMatchedTOF1": SignalTimeMatchedTOF1,
                             "SignalTimeMatchedTOF0": SignalTimeMatchedTOF0,
-                            # "nPeaksMatched": df_TOF1_hitTimes["nPeaks"],
+                            "WindowLowerTime": window_lower_bound,
+                            "WindowUpperTime":
+                            window_upper_bound,
+                            "WindowCentralTime":
+                            window_central_time,
+                            "WindowCentralTimeCorrected":
+                            window_central_time_corrected
                             })
 
 
-    branches = {"Pedestal": read_nTuple(df, "Pedestal", isSqueezed = True),
-                "PedestalSigma": read_nTuple(df, "PedestalSigma", isSqueezed = True),
-                "MaxVoltage": read_nTuple(df, "MaxVoltage", isSqueezed = True),
-                "WholeWaveformInt": read_nTuple(df, "WholeWaveformInt", isSqueezed = True),
-                "DigiTimingOffset": read_nTuple(df, "DigiTimingOffset", isSqueezed = True),
-                "Peaks": peaks,
-                "WindowPeaks": window_peaks,
-                **optional_branches}
+        branches = {"Pedestal": read_nTuple(df, "Pedestal", isSqueezed = True),
+                    "PedestalSigma": read_nTuple(df, "PedestalSigma", isSqueezed = True),
+                    "MaxVoltage": read_nTuple(df, "MaxVoltage", isSqueezed = True),
+                    "WholeWaveformInt": read_nTuple(df, "WholeWaveformInt", isSqueezed = True),
+                    "WholeWaveformIntPE": read_nTuple(df, "WholeWaveformIntPE", isSqueezed = True),
+                    "DigiTimingOffset": read_nTuple(df, "DigiTimingOffset", isSqueezed = True),
+                    "Peaks": peaks,
+                    "WindowPeaks": window_peaks,
+                    **optional_branches}
 
     print(f" ... writing {channel} to {output_file.file_path}")
 
@@ -278,72 +407,6 @@ def process_batch(waveforms, optional_branches, channel, output_file, config_arg
         output_file[channel].extend(branches)
 
 
-
-    # for key in ref_file.keys()[:-1]:
-    #     df = ref_file[key].arrays(library="pd")
-    #     #it is useful to look at only the case where we have one peak in all of the TOF
-    #     detectors_pd.append(df)
-    #             # print(df[onePeakToF])
-
-
-#     detectors = run_file.keys()
-#     branch_names = run_file['TOF03'].keys()
-#     digitizer_channels = {d: {} for d in detectors}
-#
-#     for d in detectors:
-#         channels = digitizer_channels[d]
-#         print(channels,digitizer_channels)
-#         for batch, report in run_file[d].iterate(branch_names, step_size="1000 MB", report=True):
-#             print(f"... events {report.tree_entry_start} to {report.tree_entry_stop}")
-#             for c, i in channels.items():
-#                 # print(f"... ... processing {d}/{c} into {config['ChannelNames'][i]}", end="", flush=True)
-#                 config_args = {
-#                     "threshold": config["Thresholds"][i],
-#                     "analysis_window": (config["AnalysisWindowLow"][i], config["AnalysisWindowHigh"][i]),
-#                     "pedestal_window": (config["PedestalWindowLow"][i], config["PedestalWindowHigh"][i]),
-#                     "reverse_polarity": (config["Polarity"][i] == 0),
-#                     "voltage_scale": config["VoltageScale"],
-#                     "time_offset": config["TimeOffset"][i],
-#                 }
-#                 waveforms = batch[c]
-#                 #all the branches are optional and we want to keep them stored
-#                 optional_branches = {b: batch[b] for b in branch_names}
-#                 process_batch(waveforms, optional_branches, config["ChannelNames"][i], output_file, config_args)
-#
-#     run_number = int(root_filename[-11:-5])
-#     print(f"Saving event info for run {run_number}")
-#     output_file["EventInfo"] = {
-#         "RunNumber": np.repeat(run_number, n_events),
-#         "EventNumber": run_file[digitizers[0]]["eventNumber"].array(),
-#         "SpillNumber": run_file[digitizers[0]]["spillNumber"].array()
-#     }
-#     run_file.close()4
-#
-#
-# def process_batch(waveforms, optional_branches, channel, output_file, config_args):
-#     waveform_analysis = WaveformAnalysis(waveforms, **config_args)
-#     waveform_analysis.run_analysis()
-#     integrated_charges = waveform_analysis.window_int_charge
-#     #
-#     # pedestals = ak.Array(waveform_analysis.pedestals.squeeze())
-#     # pedestal_sigmas = ak.Array(waveform_analysis.pedestal_sigmas.squeeze())
-#     # peak_voltages = waveform_analysis.pulse_peak_voltages
-#     # peak_times = waveform_analysis.pulse_peak_times
-#     # signal_times = waveform_analysis.pulse_signal_times
-#     # integrated_charges = waveform_analysis.pulse_charges
-#
-#     peaks = ak.zip({"PeakVoltage": peak_voltages,
-#                     "PeakTime": peak_times,
-#                     "SignalTime": signal_times,
-#                     "IntCharge": integrated_charges})
-#
-#     branches = {**optional_branches}
-#
-#     print(f" ... writing {channel} to {output_file.file_path}")
-#     if channel not in output_file.keys():
-#         branch_types = {name: branch.type for name, branch in branches.items()}
-#         output_file.mktree(channel, branch_types, counter_name=(lambda s: "nPeaks"), field_name=(lambda s, f: f))
-#     output_file[channel].extend(branches)
 
 if __name__ == "__main__":
     # execute only if run as a script"

--- a/python/new_analysis/process_waveform_analysis.py
+++ b/python/new_analysis/process_waveform_analysis.py
@@ -120,6 +120,7 @@ def process_batch(waveforms, optional_branches, channel, output_file, config_arg
     #total ADC count, this is a hard coded factor as we do not expect it to change but please be aware
     #refer tho these slides: https://wcte.hyperk.ca/wg/beam/meetings/2023/20231211/meeting/beam-structure-and-two-particle-events/beam_structure_v5.pdf
     integrated_analysis_waveform = ak.Array(waveform_analysis.whole_waveform_int.squeeze())
+    integrated_analysis_waveform_pe = ak.Array(waveform_analysis.whole_waveform_int_pe.squeeze())
     max_voltage = ak.Array(waveform_analysis.max_voltage.squeeze())
 
     peaks = ak.zip({"PeakVoltage": peak_voltages,
@@ -137,6 +138,7 @@ def process_batch(waveforms, optional_branches, channel, output_file, config_arg
                 "DigiTimingOffset": max_voltage,
                 "MaxVoltage": max_voltage,
                 "WholeWaveformInt": integrated_analysis_waveform,
+                "WholeWaveformIntPE": integrated_analysis_waveform_pe,
                 **optional_branches}
 
     print(f" ... writing {channel} to {output_file.file_path}")

--- a/python/new_analysis/waveform_analysis_ac.py
+++ b/python/new_analysis/waveform_analysis_ac.py
@@ -235,7 +235,11 @@ class WaveformAnalysis:
             #Look at the timing as signal time: need to shift the waveform and make sure we stay within the waveform boundary
             #DigiTimingOffset (DTO) is SignalTimeCorrected (STC, Arturo's corrections) - SignalTime(ST), waveforms are given in ST and df_TOF1_hitTimes given in STC
             #expectedMin/Max are given in ST so they can be applied to the waveform
+
+            print(self.window_lower_bound, self.window_upper_bound)
             expectedMin = (self.df_TOF1_hitTimes[i]+self.window_lower_bound+self.window_time_offset - np.array(self.df_PMT["DigiTimingOffset"]))/self.ns_per_sample
+
+
             #replace the nans and stay within the boundary
             rangeLow = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(0>expectedMin, 0, expectedMin))
 
@@ -243,11 +247,8 @@ class WaveformAnalysis:
 
             expectedMax = (self.df_TOF1_hitTimes[i]+self.window_upper_bound+self.window_time_offset - np.array(self.df_PMT["DigiTimingOffset"]))/self.ns_per_sample
             #replace the nans and stay within the boundary
-            rangeHigh = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(expectedMax>waveformEnd, 0, waveformEnd))
+            rangeHigh = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(expectedMax>waveformEnd, waveformEnd, expectedMax))
 
-
-
-            # print("Range High:", rangeHigh, waveformEnd, max(rangeHigh))
 
             list_high.append(rangeHigh)
             list_low.append(rangeLow)
@@ -255,9 +256,15 @@ class WaveformAnalysis:
             rangeLow = np.array(rangeLow).reshape(len(rangeLow), 1)
             rangeHigh = np.array(rangeHigh).reshape(len(rangeHigh), 1)
 
+            print("Range Low- range high:", rangeHigh-rangeLow, rangeHigh, rangeLow)
+
             #creating a set of integration windows covering (Need to make this for every hit in TOF10
             #otherwise overlapping peaks will cause an issue.
+
+            print((allAnalysisBins > rangeLow), (allAnalysisBins < rangeHigh))
             over_integration_threshold = over_integration_threshold | ((allAnalysisBins > rangeLow) & (allAnalysisBins < rangeHigh))
+
+            print(over_integration_threshold)
 
 
             #purely copy-pasted, we do the same thing with a different integration window
@@ -281,6 +288,8 @@ class WaveformAnalysis:
 
             self.window_int_charge = ak.drop_none(np.ma.MaskedArray(pulse_charges, pulse_charges==0))
             self.window_int_pe = ak.drop_none(np.ma.MaskedArray(pulse_pe, pulse_pe==0))
+
+            print("Integrated charge:", self.window_int_charge)
         # print("At the end of the loop, the int charge is", self.window_int_charge)
 
 

--- a/python/new_analysis/waveform_analysis_ac.py
+++ b/python/new_analysis/waveform_analysis_ac.py
@@ -20,7 +20,7 @@ class WaveformAnalysis:
     use_global_pedestal = True  # assume pedestal is stable and use one value for all waveforms for the channel
 
     def __init__(self, waveforms, threshold=0.01, analysis_window=(0, 200), pedestal_window=(200, 420),
-                 reverse_polarity=True, ns_per_sample=2, voltage_scale=0.000610351, time_offset=0, window_time_offset=0, PMTgain = 1, window_lower_bound = -15, window_upper_bound = 35):
+                 reverse_polarity=True, ns_per_sample=2, voltage_scale=0.000610351, time_offset=0, window_time_offset=0, PMTgain = 1, window_lower_bound = -15, window_upper_bound = 35, PMTdistanceToTOF1 = None, distanceTOF1toTOF0 = None, checkCoincidence = False):
         self.raw_waveforms = np.array(waveforms)
         self.threshold = threshold
         self.reverse_polarity = reverse_polarity
@@ -28,6 +28,9 @@ class WaveformAnalysis:
         self.voltage_scale = voltage_scale
         self.analysis_window = analysis_window
         self.pedestal_window = pedestal_window
+        self.PMTdistanceToTOF1 = PMTdistanceToTOF1
+        self.distanceTOF1toTOF0 = distanceTOF1toTOF0
+        self.checkCoincidence = checkCoincidence
         self.analysis_bins = range(analysis_window[0]//ns_per_sample, analysis_window[1]//ns_per_sample)
         self.pedestal_bins = range(pedestal_window[0]//ns_per_sample, pedestal_window[1]//ns_per_sample)
         self.time_offset = time_offset
@@ -53,13 +56,23 @@ class WaveformAnalysis:
         self.pulse_signal_times = None
         self.pulse_charges = None
         self.pulse_pe = None
+        self.windowWidth = None
         #new - window integration
         self.window_int_charge = None
         self.window_int_pe = None
+        #new save bounds of the integration window and ccentral value
+        self.windowIntCentralTime = None
+        self.windowIntCentralTimeCorrected = None
+        self.windowIntUpperTime = None
+        self.windowIntLowerTime = None
         #new - complete waveform integration for two particle ID
         self.whole_waveform_int = None
+        self.whole_waveform_int_pe = None
         self.max_voltage = None
         self.PMTgain = PMTgain
+        self.waveformEnd = None
+
+        
 
     def find_pedestals(self):
         """Finds the pedestal of each waveform by taking the mean in the pedestal window. Also finds the standard deviation"""
@@ -213,22 +226,38 @@ class WaveformAnalysis:
         analysis_waveform = self.smoothed_waveforms
         #npew the analysis is over all bins
         # print(self.analysis_bins)
-        waveformEnd = len(self.smoothed_waveforms[0])
-        allAnalysisBins = np.tile(np.arange(0, waveformEnd),(self.waveforms.shape[0],1))
+        self.waveformEnd = len(self.smoothed_waveforms[0])
+        allAnalysisBins = np.tile(np.arange(0, self.waveformEnd),(self.waveforms.shape[0],1))
 
         list_high = []
         list_low = []
         #select all of the windows of integration
 
-        # print(sum(self.df_TOF1_hitTimes["nPeaks"]))
-        pulse_charges = np.zeros((self.waveforms.shape[0], max(self.df_TOF1_hitTimes["nPeaks"])))
-        pulse_pe = np.zeros((self.waveforms.shape[0], max(self.df_TOF1_hitTimes["nPeaks"])))
+        #maximum number of hits that were found
+        nPeaksMax = max(self.df_TOF1_hitTimes["nPeaks"])
 
-        # print("The max number of nPeak is", max(self.df_TOF1_hitTimes["nPeaks"]))
+        pulse_charges = np.zeros((self.waveforms.shape[0],nPeaksMax))
+        pulse_pe = np.zeros((self.waveforms.shape[0],nPeaksMax))
+        windowWidth_array = np.zeros((self.waveforms.shape[0],nPeaksMax))
 
-        # print(self.df_TOF1_hitTimes, 'The dataframe')
+        #saving the timing characterisics of the waveform
+        windowIntCentralTime = np.zeros((self.waveforms.shape[0],nPeaksMax))
+        windowIntCentralTimeCorrected = np.zeros((self.waveforms.shape[0],nPeaksMax))
+        windowIntLowerBound = np.zeros((self.waveforms.shape[0],nPeaksMax))
+        windowIntUpperBound = np.zeros((self.waveforms.shape[0],nPeaksMax))
 
-        for i in range(max(self.df_TOF1_hitTimes["nPeaks"])):
+
+
+        #here, take into account the particle time of flight to predict where to 
+        #centre the integration window, but only when we have calculated the coincidence
+        # print("Particle time of flight: ",  self.particleTimeOfFlight[:10], " PMT distance to TOF1: ", self.PMTdistanceToTOF1, "previous offset: ",  self.window_time_offset)
+        
+        
+
+
+
+
+        for i in range(nPeaksMax):
             over_integration_threshold = False
             #need to get rid of the NaN issues and look at bin id instead of ns
 
@@ -236,19 +265,31 @@ class WaveformAnalysis:
             #DigiTimingOffset (DTO) is SignalTimeCorrected (STC, Arturo's corrections) - SignalTime(ST), waveforms are given in ST and df_TOF1_hitTimes given in STC
             #expectedMin/Max are given in ST so they can be applied to the waveform
 
-            print(self.window_lower_bound, self.window_upper_bound)
+            #we keep the absolute offset so we have an easy handle on that 
+            # if self.checkCoincidence:
+            #     self.window_time_offset = self.particleTimeOfFlight[i] * self.PMTdistanceToTOF1/self.distanceTOF1toTOF0 + self.window_time_offset 
+
+            #     print("Sample of time of flight induced timing offset in position of window integration: ", np.array(self.window_time_offset[:5]))
+
             expectedMin = (self.df_TOF1_hitTimes[i]+self.window_lower_bound+self.window_time_offset - np.array(self.df_PMT["DigiTimingOffset"]))/self.ns_per_sample
 
 
-            #replace the nans and stay within the boundary
-            rangeLow = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(0>expectedMin, 0, expectedMin))
-
-            # print("Range Low:", rangeLow,  min(rangeLow))
-
             expectedMax = (self.df_TOF1_hitTimes[i]+self.window_upper_bound+self.window_time_offset - np.array(self.df_PMT["DigiTimingOffset"]))/self.ns_per_sample
-            #replace the nans and stay within the boundary
-            rangeHigh = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(expectedMax>waveformEnd, waveformEnd, expectedMax))
 
+            #replace the nans and stay within the boundary
+            rangeLow = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(0>expectedMin, np.where(0<expectedMax, 0, -9999), expectedMin))
+
+            #replace the nans and stay within the boundary
+            rangeHigh = np.where(np.isnan(self.df_TOF1_hitTimes[i]), -9999, np.where(expectedMax>self.waveformEnd, np.where(expectedMin<self.waveformEnd, self.waveformEnd, -9999), expectedMax))
+            # if debug:
+            #     print("Check range Low", rangeLow, rangeLow[1888], rangeLow[1890], rangeLow[1891] )
+            #     print("Check range High", rangeHigh, rangeHigh[1888], rangeHigh[1890], rangeHigh[1891] )
+
+            windowWidth = rangeHigh-rangeLow 
+
+            #need to keep this format before the reshaping to save the bound
+            lowerBound = rangeLow
+            upperBound = rangeHigh
 
             list_high.append(rangeHigh)
             list_low.append(rangeLow)
@@ -256,15 +297,16 @@ class WaveformAnalysis:
             rangeLow = np.array(rangeLow).reshape(len(rangeLow), 1)
             rangeHigh = np.array(rangeHigh).reshape(len(rangeHigh), 1)
 
-            print("Range Low- range high:", rangeHigh-rangeLow, rangeHigh, rangeLow)
+
+            # print("Range Low- range high:", rangeHigh-rangeLow, rangeHigh, rangeLow, "offset:", self.df_PMT["DigiTimingOffset"])
 
             #creating a set of integration windows covering (Need to make this for every hit in TOF10
             #otherwise overlapping peaks will cause an issue.
 
-            print((allAnalysisBins > rangeLow), (allAnalysisBins < rangeHigh))
+            # print((allAnalysisBins > rangeLow), (allAnalysisBins < rangeHigh))
             over_integration_threshold = over_integration_threshold | ((allAnalysisBins > rangeLow) & (allAnalysisBins < rangeHigh))
 
-            print(over_integration_threshold)
+            # print(over_integration_threshold)
 
 
             #purely copy-pasted, we do the same thing with a different integration window
@@ -277,19 +319,40 @@ class WaveformAnalysis:
 
             for k in range(0, analysis_waveform.shape[1]):  # scan over waveform samples, quicker than iterating over waveforms
                 passed_integration_threshold = passed_integration_threshold | (integration_threshold_diff[:, k] == 1)  # check if passed integration threshold
-#                 n_peaks += pass_pulse_threshold[:, k] & passed_integration_threshold  # there's a new peak when it passes pulse threshold and has passed integration threshold
+# #                 n_peaks += pass_pulse_threshold[:, k] & passed_integration_threshold  # there's a new peak when it passes pulse threshold and has passed integration threshold
                 passed_integration_threshold &= ~pass_pulse_threshold[:, k]  # after passing pulse threshold, don't consider it passed integration threshold until it passes again
                 my_pulse_charges[integration_threshold_diff[:, k] == 1] = 0
                 my_pulse_charges[over_integration_threshold[:, k]] += analysis_waveform[over_integration_threshold[:,k],k]
                 end_of_pulse = np.where(((integration_threshold_diff[:, k] == -1) | (k == analysis_waveform.shape[1]-1)) & (~passed_integration_threshold))[0]
+
                 pulse_charges[end_of_pulse, i] = my_pulse_charges[end_of_pulse]*self.ns_per_sample/self.impedance
                 pulse_pe[end_of_pulse, i] = my_pulse_charges[end_of_pulse]/self.PMTgain
+                windowWidth_array[:, i] = windowWidth*self.ns_per_sample
+
+                #saving the edge of each of the windows
+                windowIntLowerBound[:, i] = lowerBound*self.ns_per_sample
+
+                windowIntUpperBound[:, i] = upperBound*self.ns_per_sample
+
+                windowIntCentralTime[:, i] = self.df_TOF1_hitTimes[i]+self.window_time_offset - np.array(self.df_PMT["DigiTimingOffset"])
+
+                windowIntCentralTimeCorrected[:,i] = self.df_TOF1_hitTimes[i]+self.window_time_offset
+
                 # print(pulse_charges, end_of_pulse)
 
             self.window_int_charge = ak.drop_none(np.ma.MaskedArray(pulse_charges, pulse_charges==0))
             self.window_int_pe = ak.drop_none(np.ma.MaskedArray(pulse_pe, pulse_pe==0))
+            #need to remove everything that was smaller than 1 data point
+            self.windowWidth = ak.drop_none(np.ma.MaskedArray(windowWidth_array, pulse_pe==0))
 
-            print("Integrated charge:", self.window_int_charge)
+            self.windowIntCentralTimeCorrected = ak.drop_none(np.ma.MaskedArray(windowIntCentralTimeCorrected, pulse_pe==0))
+            self.windowIntCentralTime = ak.drop_none(np.ma.MaskedArray(windowIntCentralTime, pulse_pe==0))
+            self.windowIntLowerBound = ak.drop_none(np.ma.MaskedArray(windowIntLowerBound, pulse_pe==0))
+            self.windowIntUpperBound = ak.drop_none(np.ma.MaskedArray(windowIntUpperBound, pulse_pe==0))
+
+
+
+            # print("Integrated charge:", self.window_int_charge)
         # print("At the end of the loop, the int charge is", self.window_int_charge)
 
 
@@ -329,6 +392,7 @@ class WaveformAnalysis:
         analysis_waveform = self.smoothed_waveforms[:, self.analysis_bins]
         self.whole_waveform_int = np.sum(analysis_waveform, axis=1, keepdims=True)
         self.whole_waveform_int *= 1 / (self.voltage_scale * 1000)
+        self.whole_waveform_int_pe = np.sum(analysis_waveform, axis=1, keepdims=True) / self.PMTgain
         return self.whole_waveform_int
 
 

--- a/python/particleID_final.py
+++ b/python/particleID_final.py
@@ -1,0 +1,21 @@
+#this is the final version of particle ID, baed on window integration and coicidence requirements. Previous iterarions included particleID and checkScintillation ID. Should be read only with the corresponding config file (no need for anything else)
+
+#Step 0: initialise, reading the user inputs
+# a config file that has all of the information
+ with open(config_filename) as file:
+        config = json5.load(file)["WaveAnalysis"]
+
+particleID_analysis = LowMomentumAnalysis(config)
+particleID_analysis.openDataFile()
+
+
+#Step 1: Select only events with exactly one coincidence
+particleID_analysis.selectEvents()
+
+#Step 2: dE/dx in trigger scintillator-based selection of 1 particle events (also using TOF)
+
+#Step 3: ID events using cuts on ACT signal
+
+#Step 4: Plots
+
+#Step 5: Outputs

--- a/python/particleID_final.py
+++ b/python/particleID_final.py
@@ -1,21 +1,68 @@
-#this is the final version of particle ID, baed on window integration and coicidence requirements. Previous iterarions included particleID and checkScintillation ID. Should be read only with the corresponding config file (no need for anything else)
+import sys
+import os
 
-#Step 0: initialise, reading the user inputs
-# a config file that has all of the information
- with open(config_filename) as file:
-        config = json5.load(file)["WaveAnalysis"]
+import json5
 
-particleID_analysis = LowMomentumAnalysis(config)
+import numpy as np
+
+import lowMomentum_analysis as lm
+
+config_file_name = sys.argv[1]
+
+with open(config_file_name) as file:
+    config = json5.load(file)["LowMomentumAnalysis"]
+print(config)
+
+particleID_analysis = lm.LowMomentumAnalysis(config)
 particleID_analysis.openDataFile()
 
+print(particleID_analysis.getBranchList(0))
+if config["runNumber"]<579:
+    sumDownsteamACTs = 0
+    #adding all the data from the downstream ACTs
+    for i in [4, 5, 6, 7]:
+        sumDownsteamACTs+=particleID_analysis.getDataFrameDetector(i)["matchedHit0_WindowIntPE"]
 
-#Step 1: Select only events with exactly one coincidence
-particleID_analysis.selectEvents()
+    particleID_analysis.addBranchToAllDetectors("ACT2L+ACT2R+ACT3L+ACT3R_WindowIntPE", sumDownsteamACTs)
 
-#Step 2: dE/dx in trigger scintillator-based selection of 1 particle events (also using TOF)
+if particleID_analysis.BoundsAreAvailable:
+    print("yes")
+    particleID_analysis.addOperationBranchToAllDetectors("PMThit0-WindowCentralTime", "peakHit0_SignalTimeCorrected", "-", "matchedHit0_WindowCentralTimeCorrected")
 
-#Step 3: ID events using cuts on ACT signal
 
-#Step 4: Plots
+print(particleID_analysis.getBranchList(0))
 
-#Step 5: Outputs
+#plotting below:
+subtitle = "ACTs: -16 to 45 ns - TOFs -5 to 15 ns - LG -16 to 55 - HD -26 to 45"
+extraLabel = "v5"
+
+if config["runNumber"]!=502 and config["runNumber"]!=676:
+    #dark rate runs -> not wanted
+    particleID_analysis.plotSomeDetectorHist1DfromData(["matchedHit0_TOF", "matchedHit1_TOF"], [0], "TOF_%s_%s"%(config["channelNames"][0], extraLabel), False, 10, None, subtitle, "log", 4, 400)
+
+    if config["runNumber"]<579:
+        #only dpo these plots for LM runs
+        particleID_analysis.plot2DHistFromBranches(2, "matchedHit0_WindowIntPE", 4, "ACT2L+ACT2R+ACT3L+ACT3R_WindowIntPE", "(PE)", "(PE)", subtitle, True, [100, 100], [[0, 40], [0,150]])
+        
+        #Make 2D scatter branches from the branches that we have, with different detectors The z is a third variable 
+        particleID_analysis.plot2DScatterFromBranches(0, "matchedHit0_TOF", -1, "peakHit0_IntPE", 4, "ACT2L+ACT2R+ACT3L+ACT3R_WindowIntPE", "(ns)", "(PE)", "(PE)", subtitle, True)
+
+particleID_analysis.nCoincidenceSelection()
+
+upperBounds = [10, 10, 10, 10, 150, 150, 150, 150, 80, 80, 80, 80, 80, 80, 80, 80, 10, 10, 20]
+for detectorID in np.arange(0, len(config["channelNames"]), 1):
+    if config["channelNames"][detectorID] != None:
+        particleID_analysis.plotSomeDetectorHist1DfromData(["peakHit0_IntPE", "matchedHit0_WindowIntPE", "WholeWaveformIntPE"], [detectorID], "%s_charge_all_%s"%(config["channelNames"][detectorID], extraLabel), False, -1, 200, subtitle, "log", 4, 200)
+
+        particleID_analysis.plotSomeDetectorHist1DfromData(["PMThit0-WindowCentralTime"], [detectorID], "%s_time_all_%s"%(config["channelNames"][detectorID], extraLabel), False, -20, 20, subtitle, "", 4, 200, True)
+
+#plotting below:
+subtitle = "NON-PROTONS ONLY ACTs: -16 to 45 ns - TOFs -5 to 15 ns - LG -16 to 55 - HD -26 to 45"
+
+particleID_analysis.selectBasedOnCondition(0, "matchedHit0_TOF", '<', 15)
+
+for detectorID in np.arange(0, len(config["channelNames"]), 1):
+    if config["channelNames"][detectorID] != None:
+        particleID_analysis.plotSomeDetectorHist1DfromData(["matchedHit0_WindowIntPE", "WholeWaveformIntPE"], [detectorID], "%s_charge_nonProtons_%s"%(config["channelNames"][detectorID], extraLabel), False, -1, 200, subtitle, "log", 4, 200)
+
+        particleID_analysis.plotSomeDetectorHist1DfromData(["PMThit0-WindowCentralTime"], [detectorID], "%s_time_nonProtons_%s"%(config["channelNames"][detectorID], extraLabel), False, None, None, subtitle, "", 4, 200, True)


### PR DESCRIPTION
Works really well for low momentum set-up. Timing match is not as good for hodoscope elements but good for other detectors. 

Recommend keeping a wide integration window (-26 to 45) for HD elements if one wants to look at window integrated number of PE (the timing match is not always perfect for those detectors, but it is good for lead glass).

New branches:
 - WholeWaveformIntPE
 -  WindowCentralTime
 - WindowCentralTimeCorrected
 - WindowLowerTime
 - WindowUpperTime
 - WindowWidth
 
Need to re-run the whole complete_pre-processing.sh code before can look at the outputs (now named _final) but can change that.

The new ParticleID_final.py code can be run as follows:
'''python(3) ParticleID_final.py ../config/analyse_000432.json'''

The config file has to be adapted for each individual run you are looking at. This is not a final version, more is coming.

I am taking some time to write documentation in the beam flux overleaf, please have a look there for more information : https://wcte.hyperk.ca/wg/beam/beam-test-2023/drafts/t9-beam-flux-technical-note